### PR TITLE
v1.0.0: Caller as array, _errorHandler route as fallback route

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,28 @@
 import tasker from './tasker';
 import Router from './router';
 
+const CONFIG = {
+  Environment: tasker.global('TJS_ENV'),
+  RemoteUrl: tasker.global('TJS_DEV_REMOTE'),
+  LocalPath: tasker.global('TJS_LOCAL_PATH'),
+};
+const TASK = {
+  RunScript: 'TJS:RunScript',
+};
+
 const hotReload = () => {
-  const environment = tasker.global('TJS_ENV');
+  if (CONFIG.Environment !== 'development') return Promise.resolve();
 
-  if (environment !== 'development') return Promise.resolve();
-
-  return fetch(tasker.global('TJS_DEV_REMOTE'))
+  return fetch(CONFIG.RemoteUrl)
     .then(res => res.text())
     .then((result) => {
-      const existingFile = tasker.readFile(tasker.global('TJS_LOCAL_PATH'));
+      const existingFile = tasker.readFile(CONFIG.LocalPath);
 
       if (existingFile !== result) {
-        tasker.writeFile(tasker.global('TJS_LOCAL_PATH'), result);
+        tasker.writeFile(CONFIG.LocalPath, result);
         tasker.flash('script updated');
         tasker.performTask(
-          'TJS:RunScript',
+          TASK.RunScript,
           tasker.local('priority'),
           JSON.stringify(tasker.locals)
         );

--- a/src/router.js
+++ b/src/router.js
@@ -14,10 +14,6 @@ export const parseCallerId = (callerId = '') => {
         route: callerRoute,
       };
     }
-    case 'ui': return {
-      type: ROUTE_TYPE.Enter,
-      route: callerSourceId,
-    };
     case 'task': return {
       type: ROUTE_TYPE.Enter,
       route: routeId,
@@ -33,9 +29,11 @@ export default class Router {
   constructor(routes, context) {
     this.context = context;
     this.routes = routes;
-    if (!this.routes.ui) {
-      this.routes.ui = {
-        enter() {},
+    if (!this.routes._errorHandler) {
+      this.routes._errorHandler = {
+        enter() {
+          context.console.log('No route matched')
+        },
         exit() {},
       };
     }
@@ -49,7 +47,7 @@ export default class Router {
         const caller = parseCallerId(callerId);
 
         // Go to route
-        const route = this.routes[caller.route] || this.routes.ui;
+        const route = this.routes[caller.route] || this.routes._errorHandler;
         return route[caller.type](locals, this.context);
       });
   }

--- a/src/router.js
+++ b/src/router.js
@@ -3,7 +3,7 @@ export const ROUTE_TYPE = {
   Exit: 'exit',
 };
 
-export const parseCallerId = (callerId) => {
+export const parseCallerId = (callerId = '') => {
   const [callerSourceId, routeId] = callerId.split('=', 2);
 
   switch (callerSourceId) {
@@ -45,7 +45,7 @@ export default class Router {
     return Promise.resolve()
       .then(() => {
         // Make route
-        const callerId = locals.callerdebug || locals.caller2 || locals.caller1 || '';
+        const callerId = locals.caller && locals.caller[locals.caller.length - 1];
         const caller = parseCallerId(callerId);
 
         // Go to route

--- a/src/tasker.js
+++ b/src/tasker.js
@@ -48,12 +48,17 @@ tasker.getParams = () => {
 // Attempt to restore param from upstream
 const localsJson = tasker.getParams()[0];
 
-tasker.locals = localsJson || local_keys
-  .reduce((acc, key) => {
-    const keyName = key.slice(1);
-    acc[keyName] = tasker.local(keyName);
-    return acc;
-  }, {});
-
+tasker.locals = ({
+  caller: (typeof caller === 'undefined') ? [] : caller,
+  ...(
+    ((typeof local_keys === 'undefined') ? [] : local_keys)
+      .reduce((acc, key) => {
+        const keyName = key.slice(1);
+        acc[keyName] = tasker.local(keyName);
+        return acc;
+      }, {})
+  ),
+  ...((typeof localsJson === 'object') ? localsJson : {}),
+});
 
 export default tasker;

--- a/test/router/dispatch.spec.js
+++ b/test/router/dispatch.spec.js
@@ -21,7 +21,7 @@ test('should dispatch routes.ui.enter function given invalid caller', async t =>
   const defaultUiEnterSpy = sinon.spy(router.routes.ui, 'enter');
 
   const locals = {
-    caller1: 'profile=enter:AnInvalidCallerId'
+    caller: ['profile=enter:AnInvalidCallerId']
   };
   await router.dispatch(locals);
 
@@ -37,7 +37,7 @@ test('should dispatch matching Profile enter caller', async t => {
   }, context);
 
   const locals = {
-    caller1: 'profile=enter:ValidCallerId'
+    caller: ['profile=enter:ValidCallerId']
   };
   await router.dispatch(locals);
 
@@ -53,7 +53,7 @@ test('should dispatch matching Profile exit caller', async t => {
   }, context);
 
   const locals = {
-    caller1: 'profile=exit:ValidCallerId'
+    caller: ['profile=exit:ValidCallerId']
   };
   await router.dispatch(locals);
 
@@ -69,7 +69,7 @@ test('should dispatch matching Task caller', async t => {
   }, context);
 
   const locals = {
-    caller1: 'task=ValidCallerId'
+    caller: ['task=ValidCallerId']
   };
   await router.dispatch(locals);
 
@@ -85,7 +85,7 @@ test('should dispatch matching UI caller', async t => {
   }, context);
 
   const locals = {
-    caller1: 'ui'
+    caller: ['ui']
   };
   await router.dispatch(locals);
 
@@ -101,7 +101,7 @@ test('should dispatch matching arbitary caller', async t => {
   }, context);
 
   const locals = {
-    caller1: 'NoneProfileOrTask=Enter:Name'
+    caller: ['NoneProfileOrTask=Enter:Name']
   };
   await router.dispatch(locals);
 

--- a/test/router/dispatch.spec.js
+++ b/test/router/dispatch.spec.js
@@ -2,34 +2,34 @@ import test from 'ava';
 import sinon from 'sinon';
 import Router from '../../src/router';
 
-test('should dispatch routes.ui.enter function given no caller', async t => {
-  const context = {};
+test('should dispatch routes._errorHandler.enter function given no caller', async t => {
+  const context = global;
   const router = new Router({}, context);
 
-  const defaultUiEnterSpy = sinon.spy(router.routes.ui, 'enter');
+  const defaultErrorHandlerEnterSpy = sinon.spy(router.routes._errorHandler, 'enter');
 
   const locals = { /* locals without caller */ };
   await router.dispatch(locals);
 
-  t.true(defaultUiEnterSpy.calledOnceWithExactly(locals, context));
+  t.true(defaultErrorHandlerEnterSpy.calledOnceWithExactly(locals, context));
 });
 
-test('should dispatch routes.ui.enter function given invalid caller', async t => {
-  const context = {};
+test('should dispatch routes._errorHandler.enter function given invalid caller', async t => {
+  const context = global;
   const router = new Router({}, context);
 
-  const defaultUiEnterSpy = sinon.spy(router.routes.ui, 'enter');
+  const defaultErrorHandlerEnterSpy = sinon.spy(router.routes._errorHandler, 'enter');
 
   const locals = {
     caller: ['profile=enter:AnInvalidCallerId']
   };
   await router.dispatch(locals);
 
-  t.true(defaultUiEnterSpy.calledOnceWithExactly(locals, context));
+  t.true(defaultErrorHandlerEnterSpy.calledOnceWithExactly(locals, context));
 });
 
 test('should dispatch matching Profile enter caller', async t => {
-  const context = {};
+  const context = global;
   const router = new Router({
     ValidCallerId: {
       enter: sinon.fake(),
@@ -45,7 +45,7 @@ test('should dispatch matching Profile enter caller', async t => {
 });
 
 test('should dispatch matching Profile exit caller', async t => {
-  const context = {};
+  const context = global;
   const router = new Router({
     ValidCallerId: {
       exit: sinon.fake(),
@@ -61,7 +61,7 @@ test('should dispatch matching Profile exit caller', async t => {
 });
 
 test('should dispatch matching Task caller', async t => {
-  const context = {};
+  const context = global;
   const router = new Router({
     ValidCallerId: {
       enter: sinon.fake(),
@@ -77,7 +77,7 @@ test('should dispatch matching Task caller', async t => {
 });
 
 test('should dispatch matching UI caller', async t => {
-  const context = {};
+  const context = global;
   const router = new Router({
     ui: {
       enter: sinon.fake(),
@@ -93,7 +93,7 @@ test('should dispatch matching UI caller', async t => {
 });
 
 test('should dispatch matching arbitary caller', async t => {
-  const context = {};
+  const context = global;
   const router = new Router({
     'NoneProfileOrTask=Enter:Name': {
       enter: sinon.fake(),


### PR DESCRIPTION
### BREAKING CHANGE
- Breaking Change: Removed `callerdebug` and handle `caller` as an Array
    - Previously, a hardcoded variable `caller2` and `caller1` is referred. However, it is possible to have more than 2 nested caller. An array will be more suitable for extracting the caller information. See 9f1e667
- Breaking Change: Use `_errorHandler` as fallback route
    - Previously, any incorrect route will always execute the `ui` route. This PR changes this behavior. Instead `_errorHandler` will be called. By default `_errorHandler` will flash an error message "No route matched". The behavior of `_errorHandler` by providing a custom `_errorHandler` route.
